### PR TITLE
Update: Servers will use .env files to set environ details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Environments
 .venv
+.env
 
 # Python files
 .pyc

--- a/README.md
+++ b/README.md
@@ -35,8 +35,14 @@ This project runs **3 microservices**:
 - [Docker](https://www.docker.com/get-started) and [Docker Compose](https://docs.docker.com/compose/) installed  
 - Python 3.12+ (for running CLI tools)  
 - MongoDB is containerized via Docker (no local installation required)  
+- A .env file must exist inside backend folder (imagine multi machines for staging, demo or testing) with the following values
+  
+   - CONFIG_DB_URL=mongodb://mongo:27017
+   - CONFIG_DB_NAME=backend_config
+   - CONFIG_DB_COLLECTION=configs
+   - ENV=dev
+    
 
----
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,8 @@ services:
       - users
       - orders
       - mongo
-    environment:
-      CONFIG_DB_URL: mongodb://mongo:27017
-      CONFIG_DB_NAME: backend_config
-      CONFIG_DB_COLLECTION: configs
+    env_file: 
+      - ./backend/.env
     command: uvicorn main:app --host 0.0.0.0 --port 8080 --reload
 
   mongo:


### PR DESCRIPTION
Changes as follows:

1. .env file used in docker compose for loading machine env settings
2. readme updates
3. fixed config loader issue: was always using fallback env instead of mongodb.